### PR TITLE
Convert CID to Reserve Address and URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
         "algosdk": "^1.13.1",
+        "multiformats": "^9.6.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "4.0.3",
@@ -15698,6 +15699,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "node_modules/multiformats": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
+      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -36543,6 +36549,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "multiformats": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
+      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
     },
     "nanoid": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "algosdk": "^1.13.1",
+    "multiformats": "^9.6.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",


### PR DESCRIPTION
Really appreciate you guys putting this together!

If you're interested, this PR extends the functionality so that users can paste in the IPFS CID of their NFT metadata and derive the ASA URL and Reserve Address according to the ARC19 spec. This way, the user can skip the extra step of deriving the hex digest beforehand, and can also use the correctly formatted URL property.

Example CID V1 
- User input:`bafybeifceujbfpq7576clwrvp4keudpoo5au6psym4an5xh6r7s5r5nc6a/nfd.json`
- URL: `template-ipfs://{ipfscid:1:dag-pb:reserve:sha2-256}/nfd.json`
- Reserve Address: `UISREEV6D7X7YJO2GV7RISQN5Z3UCTZ6LBTQBXW472H6LWHVULYDIOVY5U`. 

Example CID V0 
- User input: `QmXcFaURxQkqJPMzkdW4EMEtpqDC4mWeDZTk5ckhoHmu5a` 
- URL: `template-ipfs://{ipfscid:0:dag-pb:reserve:sha2-256}`
- Reserve Address: `RG4FD7X6NNTK7VWU7NOUXY6GHMM3NHKRTZYMVN4I3YDYOETGQN4SELX3SY`



